### PR TITLE
Upgraded to Akka.Persistence 1.4.1-rc1.

### DIFF
--- a/Akka.Persistence.Reminders.Tests/Akka.Persistence.Reminders.Tests.csproj
+++ b/Akka.Persistence.Reminders.Tests/Akka.Persistence.Reminders.Tests.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka.Persistence" Version="1.3.10" />
-    <PackageReference Include="Akka.TestKit.Xunit" Version="1.3.10" />
+    <PackageReference Include="Akka.Persistence" Version="1.4.1-rc1" />
+    <PackageReference Include="Akka.TestKit.Xunit" Version="1.4.1-rc1" />
     <PackageReference Include="FluentAssertions" Version="5.5.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/Akka.Persistence.Reminders.Tests/ReminderSpec.cs
+++ b/Akka.Persistence.Reminders.Tests/ReminderSpec.cs
@@ -1,7 +1,7 @@
 ﻿#region copyright
 // -----------------------------------------------------------------------
 //  <copyright file="ReminderSpec.cs" creator="Bartosz Sypytkowski">
-//      Copyright (C) 2017 Bartosz Sypytkowski <b.sypytkowski@gmail.com>
+//      Copyright (C) 2017-2020 Bartosz Sypytkowski <b.sypytkowski@gmail.com>
 //  </copyright>
 // -----------------------------------------------------------------------
 #endregion
@@ -11,7 +11,7 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using Akka.Actor;
-using Akka.Configuration;
+using Hocon;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -57,7 +57,7 @@ namespace Akka.Persistence.Reminders.Tests
 
         private int seqNrCounter = 0;
 
-        private static readonly Config TestConfig = ConfigurationFactory.ParseString(@"
+        private static readonly Config TestConfig = HoconConfigurationFactory.ParseString(@"
                 akka.persistence.snapshot-store.local.dir = ""target/snapshots-ReminderSpec/""")
             .WithFallback(Reminder.DefaultConfig);
 

--- a/Akka.Persistence.Reminders.Tests/SerializationSpec.cs
+++ b/Akka.Persistence.Reminders.Tests/SerializationSpec.cs
@@ -1,16 +1,13 @@
 ﻿#region copyright
 // -----------------------------------------------------------------------
 //  <copyright file="SerializationSpec.cs" creator="Bartosz Sypytkowski">
-//      Copyright (C) 2017 Bartosz Sypytkowski <b.sypytkowski@gmail.com>
+//      Copyright (C) 2017-2020 Bartosz Sypytkowski <b.sypytkowski@gmail.com>
 //  </copyright>
 // -----------------------------------------------------------------------
 #endregion
 
 using System;
-using System.Collections.Immutable;
 using Akka.Persistence.Reminders.Serialization;
-using Akka.Serialization;
-using Cronos;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;

--- a/Akka.Persistence.Reminders/Akka.Persistence.Reminders.csproj
+++ b/Akka.Persistence.Reminders/Akka.Persistence.Reminders.csproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <AssemblyTitle>Akka.Persistence.Reminders</AssemblyTitle>
     <Description>Long running Akka.NET scheduler backed by Akka.Persistence </Description>
-    <TargetFrameworks>net45;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <PackageTags>akka.net;actors;persistence;reminders;scheduler</PackageTags>
-    <Copyright>Copyright © 2017 Akka.NET Team</Copyright>
+    <Copyright>Copyright © 2017-2020 Akka.NET Team</Copyright>
     <Authors>Bartosz Sypytkowski</Authors>
     <VersionPrefix>0.2</VersionPrefix>
     <PackageProjectUrl>https://github.com/Horusiath/Akka.Persistence.Reminders</PackageProjectUrl>
@@ -27,7 +27,7 @@
     <Reference Include="System.Data.DataSetExtensions" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Akka.Persistence" Version="1.3.10" />
+    <PackageReference Include="Akka.Persistence" Version="1.4.1-rc1" />
     <PackageReference Include="Cronos" Version="0.7.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Akka.Persistence.Reminders/Reminder.Messages.cs
+++ b/Akka.Persistence.Reminders/Reminder.Messages.cs
@@ -1,14 +1,13 @@
 ﻿#region copyright
 // -----------------------------------------------------------------------
 //  <copyright file="Reminder.Messages.cs" creator="Bartosz Sypytkowski">
-//      Copyright (C) 2017 Bartosz Sypytkowski <b.sypytkowski@gmail.com>
+//      Copyright (C) 2017-2020 Bartosz Sypytkowski <b.sypytkowski@gmail.com>
 //  </copyright>
 // -----------------------------------------------------------------------
 #endregion
 
 using System;
 using System.Collections.Immutable;
-using System.Text.RegularExpressions;
 using Akka.Actor;
 using Cronos;
 

--- a/Akka.Persistence.Reminders/Reminder.cs
+++ b/Akka.Persistence.Reminders/Reminder.cs
@@ -1,7 +1,7 @@
 ﻿#region copyright
 // -----------------------------------------------------------------------
 //  <copyright file="Reminder.cs" creator="Bartosz Sypytkowski">
-//      Copyright (C) 2017 Bartosz Sypytkowski <b.sypytkowski@gmail.com>
+//      Copyright (C) 2017-2020 Bartosz Sypytkowski <b.sypytkowski@gmail.com>
 //  </copyright>
 // -----------------------------------------------------------------------
 #endregion
@@ -9,8 +9,7 @@
 using System;
 using System.Linq;
 using Akka.Actor;
-using Akka.Configuration;
-using Akka.Event;
+using Hocon;
 
 namespace Akka.Persistence.Reminders
 {
@@ -26,7 +25,7 @@ namespace Akka.Persistence.Reminders
         /// <summary>
         /// A default set of configuration parameters used by the <see cref="Reminder"/> actor.
         /// </summary>
-        public static Config DefaultConfig => ConfigurationFactory.FromResource<Reminder>("Akka.Persistence.Reminders.reference.conf");
+        public static Config DefaultConfig => HoconConfigurationFactory.FromResource<Reminder>("Akka.Persistence.Reminders.reference.conf");
 
         /// <summary>
         /// An actor <see cref="Akka.Actor.Props"/> for <see cref="Reminder"/> class setup using default settings.

--- a/Akka.Persistence.Reminders/ReminderSettings.cs
+++ b/Akka.Persistence.Reminders/ReminderSettings.cs
@@ -1,13 +1,13 @@
 #region copyright
 // -----------------------------------------------------------------------
 //  <copyright file="ReminderSettings.cs" creator="Bartosz Sypytkowski">
-//      Copyright (C) 2017 Bartosz Sypytkowski <b.sypytkowski@gmail.com>
+//      Copyright (C) 2017-2020 Bartosz Sypytkowski <b.sypytkowski@gmail.com>
 //  </copyright>
 // -----------------------------------------------------------------------
 #endregion
 
 using System;
-using Akka.Configuration;
+using Hocon;
 
 namespace Akka.Persistence.Reminders
 {

--- a/Akka.Persistence.Reminders/Serialization/ReminderSerializer.cs
+++ b/Akka.Persistence.Reminders/Serialization/ReminderSerializer.cs
@@ -30,7 +30,7 @@ namespace Akka.Persistence.Reminders.Serialization
         public static readonly byte[] EmptyBytes = new byte[0];
 
         private readonly ExtendedActorSystem _system;
-        protected Akka.Serialization.Serialization Serialization => _system.Serialization;
+        private Akka.Serialization.Serialization Serialization => _system.Serialization;
 
         public ReminderSerializer(ExtendedActorSystem system) : base(system)
         {

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An Akka.NET scheduler designed to work with long running tasks. When compared to
 
 
 ```csharp
-var config = ConfigurationFactory.Load().WithFallback(Reminder.DefaultConfig);
+var config = HoconConfigurationFactory.Load().WithFallback(Reminder.DefaultConfig);
 using (var system = ActorSystem.Create("system", config))
 {
 	// create a reminder

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+#### 0.3 March 09 2020
+* Updated Akka.Persistence and Akka.TestKit.Xunit to 1.4.1-rc1
+* Removed support for .NET 4.5 as no longer supported by Akka.Persistence
+* Bumped version to .NET Standard 2.0 to synchronized with Akka.Persistence
+* Bumped version of Tests to .NET Core 2.0 (minumum required by .NET Standard 2.0)
+* Replaced Akka.Configuration.ConfigurationFactory with Hocon.HoconConfigurationFactory
+
 #### 0.2 February 06 2019
 * Added support for cron expressions.
 


### PR DESCRIPTION
* Updated Akka.Persistence and Akka.TestKit.Xunit to 1.4.1-rc1
* Removed support for .NET 4.5 as no longer supported by Akka.Persistence
* Bumped version to .NET Standard 2.0 to synchronized with Akka.Persistence
* Bumped version of Tests to .NET Core 2.0 (minumum required by .NET Standard 2.0)
* Replaced Akka.Configuration.ConfigurationFactory with Hocon.HoconConfigurationFactory
